### PR TITLE
Play 2.6 support (Updated to use sbt-native-packager 1.2.0)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= List(
 
 javaVersionPrefix in javaVersionCheck := Some("1.7")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3" % "provided")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0" % "provided")
 
 version := "git describe --tags --dirty --always".!!.stripPrefix("v").trim
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.16

--- a/src/main/scala/AspectJWeaver.scala
+++ b/src/main/scala/AspectJWeaver.scala
@@ -2,12 +2,14 @@ package com.gilt.sbt.aspectjweaver
 
 import sbt._
 import sbt.Keys._
-
 import com.typesafe.sbt.SbtNativePackager._
-import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
-import com.typesafe.sbt.packager.archetypes.JavaAppPackaging.autoImport.bashScriptExtraDefines
+import com.typesafe.sbt.packager.Keys.bashScriptExtraDefines
+import com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptPlugin
 
 object AspectJWeaver extends AutoPlugin {
+
+  override def requires = BashStartScriptPlugin
+
   object autoImport {
     val aspectJWeaverVersion = settingKey[String]("AspectJWeaver version")
     val aspectJWeaverAgent = taskKey[File]("AspectJWeaver agent jar location")
@@ -15,11 +17,9 @@ object AspectJWeaver extends AutoPlugin {
 
   import autoImport._
 
-  override def requires = JavaAppPackaging
-
   val ajConfig = config("aspectjweaver-agent").hide
 
-  override lazy val projectSettings = Seq(
+  override def projectSettings = Seq(
     ivyConfigurations += ajConfig,
     aspectJWeaverVersion := "1.8.8",
     aspectJWeaverAgent := findAspectJWeaverAgent(update.value),

--- a/src/main/scala/AspectJWeaver.scala
+++ b/src/main/scala/AspectJWeaver.scala
@@ -21,7 +21,7 @@ object AspectJWeaver extends AutoPlugin {
 
   override def projectSettings = Seq(
     ivyConfigurations += ajConfig,
-    aspectJWeaverVersion := "1.8.8",
+    aspectJWeaverVersion := "1.8.10",
     aspectJWeaverAgent := findAspectJWeaverAgent(update.value),
     libraryDependencies += "org.aspectj" % "aspectjweaver" % aspectJWeaverVersion.value % ajConfig,
     mappings in Universal += aspectJWeaverAgent.value -> "aspectjweaver/aspectjweaver.jar",


### PR DESCRIPTION
- Updated to work with Play 2.6
- Updated SBT version to 0.13.16
- Updated default version of AspectJ to 1.8.10

Tested in conjunction with kamon-core/kamon-play